### PR TITLE
bloomfilter32: Remove unused 'hash' property param

### DIFF
--- a/bloomfilter32.php
+++ b/bloomfilter32.php
@@ -51,12 +51,12 @@ class BloomFilter32 {
 		return new self($m,$k);
 	}
 	public static function getUnion($bf1,$bf2){
-		$bf = new self($bf1->m,$bf1->k,$bf1->hash);
+		$bf = new self($bf1->m,$bf1->k);
 		self::merge($bf1,$bf2,$bf,true);
 		return $bf;
 	}
 	public static function getIntersection($bf1,$bf2){
-		$bf = new self($bf1->m,$bf1->k,$bf1->hash);
+		$bf = new self($bf1->m,$bf1->k);
 		self::merge($bf1,$bf2,$bf,false);
 		return $bf;
 	}


### PR DESCRIPTION
Found by Phan 2.2.4:

> BloomFilter32.php:…: PhanParamTooMany Call with 3 arg(s) to \BloomFilter32::__construct() which only takes 2 arg(s) defined at …
> BloomFilter32.php:…: PhanParamTooMany Call with 3 arg(s) to \BloomFilter32::__construct() which only takes 2 arg(s) defined at …